### PR TITLE
chore(build): serve parcel without HMR

### DIFF
--- a/packages/reactjs/package.json
+++ b/packages/reactjs/package.json
@@ -6,7 +6,7 @@
     "build": "",
     "precommit": "yarn lint",
     "lint": "eslint 'src/**/*.js*'",
-    "start": "parcel src/index.html",
+    "start": "parcel src/index.html --no-hmr",
     "test": "jest --all --verbose --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:local": "jest --all --verbose --coverage"
   },


### PR DESCRIPTION
## Description
Disable HMR when running Parcel.

## Motivation and Context
Electron cannot currently handle loading websockets when a custom protocol is used.
We are not actively utilizing HMR from parcel regardless, which means we can safely
disable it when running Parcel.

An electron bug has been filed: https://github.com/electron/electron/issues/12855

## How Has This Been Tested?
I ran the nOS client on the `feat/nos-protocol` branch and loaded the content at `nos://localhost:1234` successfully.

## Screenshots (if appropriate):
<img width="1362" alt="screen shot 2018-05-08 at 8 53 06 am" src="https://user-images.githubusercontent.com/169093/39761255-3e485e82-529d-11e8-8a34-3335fe45645c.png">

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
N/A